### PR TITLE
Fix msgboxes not disappearing

### DIFF
--- a/data/maps/BattleFrontier_ExchangeServiceCorner/scripts.inc
+++ b/data/maps/BattleFrontier_ExchangeServiceCorner/scripts.inc
@@ -458,6 +458,7 @@ BattleFrontier_ExchangeServiceCorner_EventScript_ChooseBerry::
 	case 8, BattleFrontier_ExchangeServiceCorner_EventScript_Hondew
 	case 9, BattleFrontier_ExchangeServiceCorner_EventScript_Grepa
 	case 10, BattleFrontier_ExchangeServiceCorner_EventScript_Tamato
+	case 11, BattleFrontier_ExchangeServiceCorner_EventScript_ClerkGoodbye
 	case MULTI_B_PRESSED, BattleFrontier_ExchangeServiceCorner_EventScript_ClerkGoodbye
 	end
 

--- a/data/maps/SootopolisCity_PokemonCenter_1F/scripts.inc
+++ b/data/maps/SootopolisCity_PokemonCenter_1F/scripts.inc
@@ -33,6 +33,7 @@ SootopolisCity_PokemonCenter_1F_EventScript_GentlemanNoLegendaries::
 	end
 SootopolisCity_PokemonCenter_1F_EventScript_GentlemanNoLegendaries2::
 	msgbox SootopolisCity_PokemonCenter_1F_Text_WallaceToughestInHoenn2, MSGBOX_DEFAULT
+	release
 	end
 
 SootopolisCity_PokemonCenter_1F_EventScript_Woman::


### PR DESCRIPTION
- When exiting the battle frontier berry shop by hitting A on the EXIT menu entry, an msgbox with the text EXIT stays on screen
- In Sootopolis pokecenter, there is a gentleman whose msgbox does not disappear after talking to him