### PR TITLE
Grammar fix for Maxie in Magma Hideout

### DIFF
--- a/data/maps/MagmaHideout_4F/scripts.inc
+++ b/data/maps/MagmaHideout_4F/scripts.inc
@@ -209,7 +209,7 @@ MagmaHideout_4F_Text_MaxieGroudonWhatsWrong:
 	.string "was disrupted.$"
 
 MagmaHideout_4F_Text_MaxieOhItWasYou:
-	.string "MAXIE: Oh, its you?\n"
+	.string "MAXIE: Oh, it's you?\n"
 	.string "Everything is already in motion.\p"
 	.string "GROUDON will purge the ceaseless tides\n"
 	.string "and restore balance.\p"


### PR DESCRIPTION
A very minor grammar text fix for Maxie in the Magma Hideout incorrectly using "its" instead of "it's" as a contraction for "it is".

Previous:
"MAXIE: Oh, its you?"

Updated:
MAXIE: Oh, it's you?

(Contraction of "MAXIE: Oh, it is you?")