### PR TITLE
Fix for Tate and Liza Gym Battle Rematch getting stuck on 2nd rematch.

### DIFF
--- a/data/maps/MossdeepCity_Gym/scripts.inc
+++ b/data/maps/MossdeepCity_Gym/scripts.inc
@@ -14,7 +14,7 @@ MossdeepCity_Gym_EventScript_TryRematchReward::
 	special HasRematchBeenFought
 	goto_if_eq VAR_RESULT, TRUE, MossdeepCity_Gym_EventScript_GiveRematchReward
 MossdeepCity_Gym_EventScript_TryRematchRewardEnd::
-	ClearTrainerFlag TRAINER_TATE_AND_LIZA_3
+	ClearTrainerFlag TRAINER_TATE_AND_LIZA_5
 	releaseall
 	end
 


### PR DESCRIPTION
One of the players on my Enhancement fork noted that they couldn't pass the lvl 55 Tate and Liza Rematch and therefore unable to trigger the Legendary Birds.

I reviewed the code and found that there was a typo in the 29 December Commit 709a246 "Can rematch gym leaders infinitely after the 5th rematch" where Tate and Liza's reset flag was resetting TRAINER_TATE_AND_LIZA_3 instead of TRAINER_TATE_AND_LIZA_5.

I have updated the code and hope you can review and pull this in before your upcoming patch release so that newer players can get all Tate and Liza's rematches and unlock the Legendary Birds.