### PR TITLE
Fix acro bike landing inside walls or on NPCs

### DIFF
--- a/PullRequestReadMe.md
+++ b/PullRequestReadMe.md
@@ -1,0 +1,26 @@
+# Pull Request: Fix Acro Bike Reverse Ledge Jump
+
+## Problem
+
+In the postgame, when the player has the upgraded acro bike with bunny-hop ledge jumping enabled (`FLAG_UNLOCKED_BIKE_SWITCHING`), performing a reverse bunny-hop over a ledge could land the player inside walls or on top of NPCs. This happened because the original code used a single combined condition that only checked whether the tile was a ledge, without verifying that the destination tile (one past the ledge) was actually passable.
+
+The bug is reproducible in areas like Jagged Pass where ledges are adjacent to walls or NPCs.
+
+## Fix
+
+Split the `GetLedgeJumpDirection()` ledge jump condition into two separate checks:
+
+1. **Normal ledge jumps** (player facing the same direction as the ledge orientation) continue to work exactly as before with no changes.
+2. **Reverse bunny-hop jumps** (postgame feature) now call `GetCollisionAtCoords()` on the landing tile before allowing the jump. This function checks for:
+   - Impassable wall tiles
+   - NPCs occupying the tile
+   - Elevation mismatches
+   - Map border collisions
+
+   The reverse jump is only allowed if the destination returns `COLLISION_NONE`.
+
+Normal postgame ledge jumping still works in all valid directions — only jumps that would land the player in an invalid position are blocked.
+
+## File Changed
+
+- `src/event_object_movement.c` — `GetLedgeJumpDirection()` function (around line 7672)

--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -7680,6 +7680,8 @@ u8 GetLedgeJumpDirection(s16 x, s16 y, u8 direction)
 
     u8 behavior;
     u8 index = direction;
+    struct ObjectEvent *playerObjEvent = &gObjectEvents[gPlayerAvatar.objectEventId];
+    s16 destX, destY;
 
     if (index == DIR_NONE)
         return DIR_NONE;
@@ -7689,9 +7691,22 @@ u8 GetLedgeJumpDirection(s16 x, s16 y, u8 direction)
     index--;
     behavior = MapGridGetMetatileBehaviorAt(x, y);
 
-    if (ledgeBehaviorFuncs[index](behavior) == TRUE || (gPlayerAvatar.acroBikeState == ACRO_STATE_BUNNY_HOP &&
-    MB_JUMP_EAST <= behavior && behavior <= MB_JUMP_SOUTH && FlagGet(FLAG_UNLOCKED_BIKE_SWITCHING)))
+    // Normal ledge jump: direction matches ledge orientation
+    if (ledgeBehaviorFuncs[index](behavior) == TRUE)
         return index + 1;
+
+    // Postgame bunny-hop reverse jump: any ledge direction allowed,
+    // but check that the landing tile (one past the ledge) is passable and unoccupied
+    if (gPlayerAvatar.acroBikeState == ACRO_STATE_BUNNY_HOP
+        && MB_JUMP_EAST <= behavior && behavior <= MB_JUMP_SOUTH
+        && FlagGet(FLAG_UNLOCKED_BIKE_SWITCHING))
+    {
+        destX = x;
+        destY = y;
+        MoveCoords(index + 1, &destX, &destY);
+        if (GetCollisionAtCoords(playerObjEvent, destX, destY, index + 1) == COLLISION_NONE)
+            return index + 1;
+    }
 
     return DIR_NONE;
 }


### PR DESCRIPTION
# Fix acro bike landing inside walls or on NPCs

## Problem

In the postgame, when the player has the upgraded acro bike with bunny-hop ledge jumping enabled (`FLAG_UNLOCKED_BIKE_SWITCHING`), performing a reverse bunny-hop over a ledge could land the player inside walls or on top of NPCs. This happened because the original code used a single combined condition that only checked whether the tile was a ledge, without verifying that the destination tile (one past the ledge) was actually passable.

The bug is reproducible in areas like Jagged Pass where ledges are adjacent to walls or NPCs.

## Fix

Split the `GetLedgeJumpDirection()` ledge jump condition into two separate checks:

1. **Normal ledge jumps** (player facing the same direction as the ledge orientation) continue to work exactly as before with no changes.
2. **Reverse bunny-hop jumps** (postgame feature) now call `GetCollisionAtCoords()` on the landing tile before allowing the jump. This function checks for:
   - Impassable wall tiles
   - NPCs occupying the tile
   - Elevation mismatches
   - Map border collisions

   The reverse jump is only allowed if the destination returns `COLLISION_NONE`.

Normal postgame ledge jumping still works in all valid directions — only jumps that would land the player in an invalid position are blocked.

## File Changed

- `src/event_object_movement.c` — `GetLedgeJumpDirection()` function (around line 7672)
