### PR TITLE
Fix invisible Birch when entering lab for Johto starter pre-Jirachi

### DIFF
--- a/data/maps/LittlerootTown_ProfessorBirchsLab/scripts.inc
+++ b/data/maps/LittlerootTown_ProfessorBirchsLab/scripts.inc
@@ -86,6 +86,12 @@ LittlerootTown_ProfessorBirchsLab_EventScript_AddRivalObject::
 	end
 
 LittlerootTown_ProfessorBirchsLab_EventScript_SetObjectPosForJohtoStarters::
+	@ Force Birch visible in the lab even if the Mossdeep Jirachi sidequest
+	@ has not been done yet — UpdateLocation also handles this via the
+	@ Johto starter state bypass, but addobject here is a safety net so
+	@ the subsequent setobjectxy/turnobject below operate on a real object.
+	clearflag FLAG_HIDE_LITTLEROOT_TOWN_BIRCHS_LAB_BIRCH
+	addobject LOCALID_BIRCH
 	goto_if_set FLAG_GOT_CYNDAQUIL, LittlerootTown_ProfessorBirchsLab_EventScript_SkipCyndaquil
 	addobject LOCALID_BALL_CYNDAQUIL
 LittlerootTown_ProfessorBirchsLab_EventScript_SkipCyndaquil::

--- a/data/scripts/prof_birch.inc
+++ b/data/scripts/prof_birch.inc
@@ -1,4 +1,10 @@
 ProfBirch_EventScript_UpdateLocation::
+	@ If the Johto-starter quest needs Birch in the lab (state >= 4 = "all
+	@ Hoenn mons caught, choose a Johto starter"), force him to the lab
+	@ regardless of whether the Mossdeep Jirachi sidequest has been done.
+	@ Mossdeep Birch is a separate object event with its own hide flag, so
+	@ this does not affect the Jirachi quest.
+	goto_if_ge VAR_DEX_UPGRADE_JOHTO_STARTER_STATE, 4, ProfBirch_EventScript_MoveToLab
 	goto_if_unset FLAG_HIDE_MOSSDEEP_CITY_BIRCH, Common_EventScript_NopReturn
 	goto_if_eq VAR_PETALBURG_GYM_STATE, 0, Common_EventScript_NopReturn
 	goto_if_set FLAG_SYS_GAME_CLEAR, ProfBirch_EventScript_MoveToLab


### PR DESCRIPTION
If the player completes the Hoenn dex before doing the Mossdeep Jirachi sidequest and walks into Birch's lab to start the Johto starter quest, an invisible Birch dialog box pops with no sprite.


Root cause: at the National dex upgrade, Birch leaves the lab to go to Mossdeep — FLAG_HIDE_LITTLEROOT_TOWN_BIRCHS_LAB_BIRCH is set and FLAG_HIDE_MOSSDEEP_CITY_BIRCH is cleared. The shared ProfBirch_EventScript_UpdateLocation early-returns whenever FLAG_HIDE_MOSSDEEP_CITY_BIRCH is unset, so it never re-shows Birch in the lab until the Jirachi sidequest completes. But EventScript_ChooseJohtoStarter (OnFrame, state 4) still triggers Birch's "you completed the dex, choose a Pokemon" dialog, and EventScript_SetObjectPosForJohtoStarters (OnWarp, state 4/5) also calls turnobject/setobjectxy on Birch without ever addobject-ing him.

Fix:
- prof_birch.inc: bypass the FLAG_HIDE_MOSSDEEP_CITY_BIRCH early return when VAR_DEX_UPGRADE_JOHTO_STARTER_STATE >= 4. State 4 is only reachable via CheckReadyForJohtoStarter which gates on HasAllHoennMons, so this only fires when the Hoenn dex has actually been completed -- pre-Hoenn-dex post-league players still see Birch correctly hidden until they finish the Jirachi quest.
- LittlerootTown_ProfessorBirchsLab/scripts.inc: belt-and- suspenders -- SetObjectPosForJohtoStarters now also clears the lab Birch hide flag and addobjects Birch before positioning him, so the OnWarp script no longer operates on a phantom.

Mossdeep Birch is a separate object event with its own hide flag, so this does not affect the Jirachi quest itself. Bug appears to be inherited from vanilla Emerald — the original code assumed the player would do the Jirachi sidequest before completing the Hoenn dex, which is not enforced anywhere.

Image for example: 

![rn_image_picker_lib_temp_d83b23bf-6a3d-4ab0-9bb1-8abfb4cfaf40](https://github.com/user-attachments/assets/3f0a93f2-350a-4b8c-b5d0-4681e630e541)
